### PR TITLE
Fix package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "dependencies": {},
   "devDependencies": {
-    "grunt": "~0.4.1",
+    "grunt": "^0.4.5",
     "grunt-autoprefixer": "~0.4.0",
     "grunt-bower-install": "~1.0.0",
     "grunt-concurrent": "~0.5.0",
@@ -13,23 +13,23 @@
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-cssmin": "~0.7.0",
     "grunt-contrib-htmlmin": "~0.1.3",
-    "grunt-contrib-imagemin": "~0.3.0",
+    "grunt-contrib-imagemin": "^2.0.1",
     "grunt-contrib-jshint": "~0.7.1",
     "grunt-contrib-uglify": "~0.2.0",
     "grunt-contrib-watch": "~0.5.2",
     "grunt-google-cdn": "~0.2.0",
+    "grunt-karma": "~0.8.3",
     "grunt-newer": "~0.6.1",
     "grunt-ngmin": "~0.0.2",
     "grunt-rev": "~0.1.0",
     "grunt-svgmin": "~0.2.0",
     "grunt-usemin": "~2.0.0",
     "jshint-stylish": "~0.1.3",
-    "load-grunt-tasks": "~0.4.0",
-    "time-grunt": "~0.2.1",
-    "grunt-karma": "~0.8.3",
-    "karma-phantomjs-launcher": "~0.1.4",
     "karma": "~0.12.16",
-    "karma-jasmine": "~0.1.5"
+    "karma-jasmine": "~0.1.5",
+    "karma-phantomjs-launcher": "~0.1.4",
+    "load-grunt-tasks": "~0.4.0",
+    "time-grunt": "~0.2.1"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
Some versions weren't compatible.
Fix the issue when doing `npm install` (mentioned in #2)

Used to output the following error:
```
$ npm install

> gifsicle@0.1.7 postinstall /Users/arianahl/opensource/f1hub/node_modules/gifsicle
> node index.js

path.js:7
    throw new TypeError('Path must be a string. Received ' + inspect(path));
    ^

TypeError: Path must be a string. Received { url: 'https://raw.github.com/imagemin/gifsicle-bin/v0.1.7/vendor/osx/gifsicle',
  name: 'gifsicle',
  os: 'darwin' }
    at assertPath (path.js:7:11)
    at Object.basename (path.js:1355:5)
    at /Users/arianahl/opensource/f1hub/node_modules/download/index.js:35:43
    at each (/Users/arianahl/opensource/f1hub/node_modules/each-async/each-async.js:63:4)
    at module.exports (/Users/arianahl/opensource/f1hub/node_modules/download/index.js:33:5)
    at /Users/arianahl/opensource/f1hub/node_modules/bin-wrapper/index.js:108:20
    at /Users/arianahl/opensource/f1hub/node_modules/bin-wrapper/index.js:141:24
    at /Users/arianahl/opensource/f1hub/node_modules/bin-check/index.js:30:20
    at /Users/arianahl/opensource/f1hub/node_modules/executable/index.js:39:20
    at FSReqWrap.oncomplete (fs.js:123:15)
```