### PR TITLE
Issue 89 - API migration

### DIFF
--- a/app/scripts/controllers/main.js
+++ b/app/scripts/controllers/main.js
@@ -64,7 +64,7 @@ angular.module('f1App')
             $scope.lookup = data;
         });
 
-        $http({method: 'get', url: $scope.baseurl + 'circuits/' + $routeParams.circuitId + '/results/'}).success(function(data) {
+        $http({method: 'get', url: $scope.baseurl + 'current/circuits/' + $routeParams.circuitId + '/results/'}).success(function(data) {
             $scope.results = data.MRData.RaceTable.Races[0];
 
             angular.forEach($scope.results.Results, function(result, idx) {

--- a/app/scripts/controllers/main.js
+++ b/app/scripts/controllers/main.js
@@ -4,13 +4,13 @@ angular.module('f1App')
     .controller('MainCtrl', function ($scope, $http) {
 
         $scope.today = new Date();
-        $scope.baseurl = 'https://ergast.com/api/f1/';
+        $scope.baseurl = 'https://api.jolpi.ca/ergast/f1';
 
         $http({method: 'get', url: 'f1.json'}).success(function(data) {
             $scope.lookup = data;
         });
 
-        $http({method: 'get', url: $scope.baseurl + 'current.json'}).success(function(data) {
+        $http({method: 'get', url: $scope.baseurl }).success(function(data) {
             $scope.season = data.MRData.RaceTable;
             for(var i in $scope.season.Races) {
                 if($scope.season.Races.hasOwnProperty(i)) {

--- a/app/scripts/controllers/main.js
+++ b/app/scripts/controllers/main.js
@@ -3,13 +3,13 @@
 angular.module('f1App')
     .controller('MainCtrl', function ($scope, $http) {
         $scope.today = new Date();
-        $scope.baseurl = 'https://api.jolpi.ca/ergast/f1/current';
+        $scope.baseurl = 'https://api.jolpi.ca/ergast/f1/';
     
         $http({method: 'get', url: 'f1.json'}).success(function(data) {
             $scope.lookup = data;
         });
     
-        $http({method: 'get', url: $scope.baseurl }).success(function(data) {
+        $http({method: 'get', url: $scope.baseurl + "current" }).success(function(data) {
             $scope.season = data.MRData.RaceTable;
             angular.forEach($scope.season.Races, function(race, index) {
                 if(race.date !== undefined) {


### PR DESCRIPTION
This pull request (PR) achieves the following key changes for F1Hub and resolving issue #89  :

### 1. Updated Base URL for All Controllers
- **Base URL:** All controllers now use the new base URL for the API: `https://api.jolpi.ca/ergast/f1/`. This is the updated endpoint after F1Hub's migration to a new API.

### 2. Controller-Specific URLs and Their Functions

Below is a detailed breakdown of each controller and the updated URLs used for specific functionalities:

#### **MainCtrl**
- **URL Utilized:**
  - `https://api.jolpi.ca/ergast/f1/current` - This URL is used to retrieve data about the current F1 season.
  
#### **ResultsCtrl**
- **URL Utilized:**
  - `https://api.jolpi.ca/ergast/f1/current/circuits/{circuitId}/results/` - Used to retrieve the race results for a specific circuit in the current season.
  - `https://api.jolpi.ca/ergast/f1/{season}/{round}/driverStandings` - Retrieves the driver standings for the specified season and round.
  - `https://api.jolpi.ca/ergast/f1/{season}/{round}/constructorStandings` - Retrieves the constructor standings for the specified season and round.

#### **QualiCtrl**
- **URL Utilized:**
  - `https://api.jolpi.ca/ergast/f1/current/circuits/{circuitId}/qualifying` - Used to fetch qualifying results for a specific circuit in the current season.

#### **SprintCtrl**
- **URL Utilized:**
  - `https://api.jolpi.ca/ergast/f1/current/circuits/{circuitId}/sprint` - Used to retrieve the sprint race results for a specific circuit in the current season.

#### **DriverCtrl**
- **URL Utilized:**
  - If no season or round is specified: `https://api.jolpi.ca/ergast/f1/current/driverStandings` - Fetches the current driver standings.
  - If season and round are provided: `https://api.jolpi.ca/ergast/f1/{season}/{round}/driverStandings` - Fetches driver standings for the given season and round.

#### **ConstructorCtrl**
- **URL Utilized:**
  - If no season or round is specified: `https://api.jolpi.ca/ergast/f1/current/constructorStandings` - Fetches the current constructor standings.
  - If season and round are provided: `https://api.jolpi.ca/ergast/f1/{season}/{round}/constructorStandings` - Fetches constructor standings for the given season and round.








