### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,8 @@ on:
     branches: [main]
 jobs:
   merge-branch:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Branch Merge


### PR DESCRIPTION
Potential fix for [https://github.com/brombomb/f1hub/security/code-scanning/1](https://github.com/brombomb/f1hub/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow uses the `GITHUB_TOKEN` to perform a branch merge, it requires `contents: write` permission to modify the repository's contents. We will add a `permissions` block at the job level to explicitly grant only the required permissions (`contents: write`) for the `merge-branch` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
